### PR TITLE
[refs #82126] Use emrt.necd.* in image.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,8 +4,8 @@ extends = eea.cfg
 [configuration]
 zope-conf-imports = eea.graylogger
 eggs +=
-  esdrt.theme
-  esdrt.content
+  emrt.necd.theme
+  emrt.necd.content
   Products.MemcachedManager
   eea.graylogger
   edw.logger
@@ -31,10 +31,10 @@ access-log-custom =
   </graylog>
 
 [versions]
-# Required by esdrt.theme
+# Required by emrt.necd.theme
 z3c.jbot = 0.7.1
 
-# Required by esdrt.content
+# Required by emrt.necd.content
 collective.collage.portlets==0.3.1
 Products.Collage = 1.3.11
 tablib=0.10.0
@@ -47,8 +47,8 @@ collective.z3cform.datagridfield = 0.11
 plone.theme = 2.1.5
 
 #own product versions
-esdrt.theme = 1.34
-esdrt.content = 1.59.34
+emrt.necd.theme = 2.0
+emrt.necd.content = 2.0
 edw.logger = 1.2
 graypy = 0.2.11
 


### PR DESCRIPTION
esdrt.content and esdrt.theme have been forked as emrt.necd.content and emrt.necd.theme, respectively.